### PR TITLE
Add useStableCallback hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://nebenan.de/",
   "repository": "good-hood-gmbh/nebenan-react-hocs",
   "bugs": "https://github.com/good-hood-gmbh/nebenan-react-hocs/issues",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "files": [
     "lib/*.js",
     "lib/*/*.js"

--- a/src/use_stable_callback/index.jsx
+++ b/src/use_stable_callback/index.jsx
@@ -1,0 +1,13 @@
+import { useCallback, useRef } from 'react';
+
+const useStableCallback = (callback) => {
+  const ref = useRef(null);
+  ref.current = callback;
+
+  return useCallback(
+    (...args) => ref.current?.(...args),
+    [],
+  );
+};
+
+export default useStableCallback;


### PR DESCRIPTION
Sometimes when callbacks are passed into components, we don't want to re-execute effects just because they changed. We want to call the most recent version of the callback at the moment of execution. 

Example: https://github.com/goodhood-eu/goodhood/blob/dfd0eeb3c053fd8401ad7b1a5434cc1bfa491139/packages/map/src/popup/index.jsx#L23

- The component doesn't know how often `onOpen` or `onClose` changes
- We don't want to re-initialize the popup because `onOpen` or `onClose` changed.
- The calling component would not assume the marker to re-initialize only because the passed `onOpen` / `onClose` changed